### PR TITLE
Add basic syntax highlight to modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.1.1
 
  - Added support for `module`
+ - Added alternative coloring for `end` when used at the beginning of a line to better support module syntax
 
 ### 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.1.1
+
+ - Added support for `module`
+
 ### 1.1.0
 
  - Renamed the language from Delve to Rel

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ vsce package
 
 ## Release Notes
 
-### 1.0.7
+### 1.1.1
+
+ - Added support for `module`
+
+### 1.1.0
 
  - Renamed the language from Delve to Rel
  - Updated logo

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ vsce package
 ### 1.1.1
 
  - Added support for `module`
+ - Added alternative coloring for `end` when used at the beginning of a line to better support module syntax
 
 ### 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "icon": "relationalai.png",
     "displayName": "Rel",
     "description": "Rel Syntax Highlighting for VSCode",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "author": {
         "name": "Mohammad Dashti and Amy Tabor",
         "email": "support@relational.ai"

--- a/syntaxes/rel.tmLanguage.json
+++ b/syntaxes/rel.tmLanguage.json
@@ -151,7 +151,7 @@
           "patterns": [
             {
               "name": "keyword.other.rel",
-              "match": "(\\b(if|then|else|end|and|or|not|eq|neq|lt|lt_eq|gt|gt_eq)\\b)|(\\+|\\-|\\*|\\/|÷|\\^|\\%|\\=|\\!\\=|≠|\\<|\\<\\=|≤|\\>|\\>\\=|≥|\\&)"
+              "match": "(\\b(if|then|else|and|or|not|eq|neq|lt|lt_eq|gt|gt_eq)\\b)|(\\+|\\-|\\*|\\/|÷|\\^|\\%|\\=|\\!\\=|≠|\\<|\\<\\=|≤|\\>|\\>\\=|≥|\\&)|\\s+(end)"
             }
           ]
         },
@@ -167,7 +167,7 @@
           "patterns": [
             {
               "name": "keyword.control.rel",
-              "match": "(\\b(def|entity|bound|include|ic|forall|exists|∀|∃|return|module)\\b)|(((\\<)?\\|(\\>)?)|∀|∃)"
+              "match": "(\\b(def|entity|bound|include|ic|forall|exists|∀|∃|return|module|^end)\\b)|(((\\<)?\\|(\\>)?)|∀|∃)"
             }
           ]
         },

--- a/syntaxes/rel.tmLanguage.json
+++ b/syntaxes/rel.tmLanguage.json
@@ -167,7 +167,7 @@
           "patterns": [
             {
               "name": "keyword.control.rel",
-              "match": "(\\b(def|entity|bound|include|ic|forall|exists|∀|∃|return)\\b)|(((\\<)?\\|(\\>)?)|∀|∃)"
+              "match": "(\\b(def|entity|bound|include|ic|forall|exists|∀|∃|return|module)\\b)|(((\\<)?\\|(\\>)?)|∀|∃)"
             }
           ]
         },


### PR DESCRIPTION
Adding syntax highlight for keyword `module` and alternative syntax highlight for keyword `end` (which is already an operator) when used right at the beginning of a line to better support module syntax.

Also bumping version from 1.1.0 to 1.1.1.